### PR TITLE
fix: alb name suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Installer for Harness SMP
 
 ## Pre-requisites
 1. Make sure you have `tofu` installed. You can check (official documentation)[https://opentofu.org/docs/intro/install/] on how to install opentofu.
+2. Ensure jq is installed and is in path.
 
 ## Run
 1. Clone this repository
@@ -35,6 +36,7 @@ Installer for Harness SMP
   ```
   go build -o smp-installer github.com/harness/smp-installer/cmd
   ```
+  Note: Any changes to .tf files should follow with build of above binary.
 3. Use the example.yaml as your configuration reference for the tool
    - Update the necessary fields as required
 5. Authenticate with AWS

--- a/pkg/tofu/aws/loadbalancer/loadbalancer.tf
+++ b/pkg/tofu/aws/loadbalancer/loadbalancer.tf
@@ -14,12 +14,14 @@ resource "random_string" "suffix" {
   length  = 4
   special = false
   lower = true
+  upper = false
 }
 
 resource "random_string" "prefix" {
   length  = 2
   special = false
   lower = true
+  upper = false
 }
 
 locals {


### PR DESCRIPTION
To fix issue during ingress creation in context of alb name having upper case: 
 a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character 